### PR TITLE
add typings for loading overlay

### DIFF
--- a/angular-loading-overlay.d.ts
+++ b/angular-loading-overlay.d.ts
@@ -1,0 +1,28 @@
+/// <reference path="../angular/index.d.ts" />
+
+declare module bs {
+    interface ILoadingOverlayService {
+        start(options?: IBsLoadingOverlayOptions): void;
+        wrap(options: IBsLoadingOverlayOptions, promiseFunction: angular.IPromise<any> | (() => (angular.IPromise<any> | {}))): angular.IPromise<any>;
+        createHandler: (options: IBsLoadingOverlayOptions) => IBsLoadingOverlayHandler;
+        notifyOverlays(referenceId: string): void;
+        stop(options?: IBsLoadingOverlayOptions): void;
+        isActive: (referenceId?: string) => boolean;
+        setGlobalConfig: (options: IBsLoadingOverlayOptions) => any;
+        getGlobalConfig: () => IBsLoadingOverlayOptions;
+    }
+
+    interface IBsLoadingOverlayOptions {
+        referenceId?: string;
+        templateUrl?: string;
+        templateOptions?: any;
+        activeClass?: string;
+        delay?: number;
+    }
+
+    interface IBsLoadingOverlayHandler {
+        start: () => void;
+        stop: () => void;
+        wrap: (promiseFunction: angular.IPromise<any> | (() => (angular.IPromise<any> | {}))) => angular.IPromise<any>;
+    }
+}


### PR DESCRIPTION
These are the typings for the angular-loading-overlay plugin introduced [here](https://github.com/Monsenso/web/pull/143/)