### PR TITLE
Add angular reference in typing for cookies

### DIFF
--- a/angular-cookies.d.ts
+++ b/angular-cookies.d.ts
@@ -6,6 +6,8 @@
 /**
  * ngCookies module (angular-cookies.js)
  */
+ 
+/// <reference path="../angularjs/angular.d.ts" />
 declare module angular.cookies {
     /**
     * Cookies options


### PR DESCRIPTION
Without the angular reference the typing can't be resolved. I forgot to add this in the previous PR.